### PR TITLE
Fix missing return type for aes_last_triangle

### DIFF
--- a/include/toslibc/tos/aes.h
+++ b/include/toslibc/tos/aes.h
@@ -304,7 +304,7 @@ DEFINE_AES_WIND_GET_XYWH(full,  FULL)
 DEFINE_AES_WIND_GET_XYWH(first, FIRST)
 DEFINE_AES_WIND_GET_XYWH(next,  NEXT)
 
-static inline aes_last_rectangle(struct aes_rectangle r)
+static inline bool aes_last_rectangle(struct aes_rectangle r)
 {
 	return !r.w && !r.h;
 }


### PR DESCRIPTION
Just a tiny fix for 
`In file included from lib/aes.c:9:
lib/../include/toslibc/tos/aes.h:307:15: error: return type defaults to 'int' [-Wimplicit-int]
  307 | static inline aes_last_rectangle(struct aes_rectangle r)`