### PR TITLE
Remove ld from the install-compiler-script

### DIFF
--- a/script/Makefile
+++ b/script/Makefile
@@ -39,7 +39,7 @@ install-linker-script: $(TOSLIBC_SCRIPT_PRG_LD)
 	$(INSTALL) -m 644 $< $(DESTDIR)$(ldscriptdir)
 
 .PHONY: install-compiler-script
-install-compiler-script: $(TOSLIBC_SCRIPT_TARGET_CC) $(TOSLIBC_SCRIPT_TARGET_LD)
+install-compiler-script: $(TOSLIBC_SCRIPT_TARGET_CC)
 	$(INSTALL) -d $(DESTDIR)$(bindir)
 	$(INSTALL) $^ $(DESTDIR)$(bindir)
 


### PR DESCRIPTION
Maybe this was the intended behavior, but if not, this suggested patch removes the $(TOSLIBC_SCRIPT_TARGET_LD) dependency from the install-compiler-script.